### PR TITLE
stable cache

### DIFF
--- a/packages/cli/src/SchemaCache.ts
+++ b/packages/cli/src/SchemaCache.ts
@@ -22,7 +22,7 @@ import crypto from "crypto";
 export default class SchemaCache {
   private map = new Map<
     string,
-    Map<number, ReturnType<typeof getDdlRelations>>
+    Map<string, ReturnType<typeof getDdlRelations>>
   >();
   // cache on file name + schema content hash.
   // we can actually get the schema declaration in its entirity from a query site.
@@ -31,7 +31,7 @@ export default class SchemaCache {
   // fill in all schemas afterwards.
   get(
     fileName: string,
-    loc: number
+    loc: string
   ): ReturnType<typeof getDdlRelations> | null {
     const existing = this.map.get(fileName);
     if (!existing) {
@@ -42,7 +42,7 @@ export default class SchemaCache {
 
   cache(
     fileName: string,
-    loc: number,
+    loc: string,
     schema: ReturnType<typeof getDdlRelations>
   ) {
     let existing = this.map.get(fileName);

--- a/packages/cli/src/file_visitor/FileVisitor.ts
+++ b/packages/cli/src/file_visitor/FileVisitor.ts
@@ -93,14 +93,29 @@ export default class FileVisitor {
       return;
     }
     let offset = 0;
-    for (const [range, replacement] of fixes) {
-      const text = this.sourceFile.getFullText();
-      const updatedText = replaceRange(text, range[0], range[1], replacement);
+    for (const fix of fixes) {
+      switch (fix._tag) {
+        case "InlineFix": {
+          const { range, replacement } = fix;
+          const text = this.sourceFile.getFullText();
+          const updatedText = replaceRange(
+            text,
+            range[0],
+            range[1],
+            replacement
+          );
 
-      // if replacement is _longer_ than what was replaced then all other replacements shift further away
-      // if replacement is _shorter_ then they shift closer
-      offset += replacement.length - (range[1] - range[0]);
-      fs.writeFileSync(this.sourceFile.fileName, updatedText);
+          // if replacement is _longer_ than what was replaced then all other replacements shift further away
+          // if replacement is _shorter_ then they shift closer
+          offset += replacement.length - (range[1] - range[0]);
+          fs.writeFileSync(this.sourceFile.fileName, updatedText);
+          break;
+        }
+        case "CompanionFileFix": {
+          // write the companion file
+          fs.writeFileSync(fix.path, fix.content);
+        }
+      }
     }
   }
 

--- a/packages/cli/src/file_visitor/QueryTypeBuilder.ts
+++ b/packages/cli/src/file_visitor/QueryTypeBuilder.ts
@@ -156,7 +156,7 @@ export default class QueryTypeBuilder {
 
     const ret = this.schemaCache.get(
       decl.getSourceFile().fileName,
-      decl.getStart()
+      normalize(decl.getFullText())
     );
     if (!ret) {
       const loc = this.sourceFile.getLineAndCharacterOfPosition(

--- a/packages/cli/src/file_visitor/QueryTypeBuilder.ts
+++ b/packages/cli/src/file_visitor/QueryTypeBuilder.ts
@@ -64,9 +64,13 @@ export default class QueryTypeBuilder {
           return null;
         }
         // const pos = this.sourceFile.getLineAndCharacterOfPosition(range[0]);
-        return [range, replacement];
+        return { _tag: "InlineFix", range, replacement };
       } catch (e: any) {
-        return [range, `<{/*${e.message}*/}>`];
+        return {
+          _tag: "InlineFix",
+          range,
+          replacement: `<{/*${e.message}*/}>`,
+        };
       }
     }
 

--- a/packages/cli/src/file_visitor/SchemaTypeBuilder.ts
+++ b/packages/cli/src/file_visitor/SchemaTypeBuilder.ts
@@ -71,9 +71,9 @@ export default class SchemaTypeBuilder {
           return null;
         }
         // const pos = this.sourceFile.getLineAndCharacterOfPosition(range[0]);
-        return [range, replacement];
+        return { _tag: "InlineFix", range, replacement };
       } catch (e: any) {
-        return [range, `<{/*${e}*/}>`];
+        return { _tag: "InlineFix", range, replacement: `<{/*${e}*/}>` };
       }
     }
 

--- a/packages/cli/src/file_visitor/types.ts
+++ b/packages/cli/src/file_visitor/types.ts
@@ -1,3 +1,15 @@
 export type Range = [number, number];
 export type Replacement = string;
-export type Fix = [Range, Replacement];
+export type Fix = InlineFix | CompanionFileFix;
+
+export type InlineFix = {
+  _tag: "InlineFix";
+  range: Range;
+  replacement: Replacement;
+};
+
+export type CompanionFileFix = {
+  _tag: "CompanionFileFix";
+  path: string;
+  content: string;
+};

--- a/sandbox/src/index.ts
+++ b/sandbox/src/index.ts
@@ -1,17 +1,17 @@
 import { schema } from "@vlcn.io/typed-sql";
 
 const App = schema<{
-  city: {
-    id: number,
-    name: string,
-    lat: number,
+  readonly city: Readonly<{
+    id: number;
+    name: string;
+    lat: number;
     long: number
-  },
-  place: {
-    id: number,
-    name: string,
+  }>;
+  readonly place: Readonly<{
+    id: number;
+    name: string;
     city_id: number
-  }
+  }>
 }>`
 CREATE TABLE city (
   id INTEGER PRIMARY KEY NOT NULL,
@@ -26,7 +26,7 @@ CREATE TABLE place (
 )`;
 
 const query = App.sql<{
-  city_id: number,
+  city_id: number;
   place_name: string
 }>`SELECT city.id as city_id, place.name as place_name 
   FROM city JOIN place`;

--- a/sandbox/src/queries.ts
+++ b/sandbox/src/queries.ts
@@ -1,13 +1,13 @@
 import { MyApp } from './schemas.js';
  
 const getUser = MyApp.sql<{
-  id: number,
+  id: number;
   name: string
 }>`SELECT * FROM user WHERE id = ?`;
 
 const getTasks = MyApp.sql<{
-  id: number,
-  what: string,
-  owner_id: number,
+  id: number;
+  what: string;
+  owner_id: number;
   list_id: number | null
 }>`SELECT * FROM task WHERE owner_id`

--- a/sandbox/src/schemas.ts
+++ b/sandbox/src/schemas.ts
@@ -1,16 +1,16 @@
 import { schema } from "@vlcn.io/typed-sql";
 
 export const MyApp = schema<{
-  user: {
+  readonly user: Readonly<{
     id: number;
     name: string
-  };
-  task: {
+  }>;
+  readonly task: Readonly<{
     id: number;
     what: string;
     owner_id: number;
     list_id: number | null
-  }
+  }>
 }>`
 CREATE TABLE user (id INTEGER PRIMARY KEY NOT NULL, name TEXT NOT NULL);
 CREATE TABLE task (


### PR DESCRIPTION
our caching of relations would return incorrect results when users had additional code formatting tools installed.

Fix all that so we never lose track of schema type definitions