### PR TITLE
lock rust-toolchain to nightly-2023-10-05 (same as cr-sqlite)

### DIFF
--- a/packages/type-gen/rust-toolchain.toml
+++ b/packages/type-gen/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2023-10-05"


### PR DESCRIPTION
I got errors trying to build `type-gen` due to incompatibility between my (global) Rust toolchain (stable -- 1.90.0) and `wasm-bindgen`:
```
error: older versions of the wasm-bindgen crate are incompatible with current versions of Rust; please update to wasm-bindgen v0.2.88
```

This is fixed by locking the Rust toolchain (in `rust-toolchain.toml`), so I copied the `rust-toolchain.toml` from https://github.com/vlcn-io/cr-sqlite package, locking the version